### PR TITLE
"Fix" Multipart Boundary Fingerprint Issue

### DIFF
--- a/lib/rex/mime/message.rb
+++ b/lib/rex/mime/message.rb
@@ -15,8 +15,10 @@ class Message
 
   def initialize(data=nil)
     self.header = Rex::MIME::Header.new
-    self.parts  = []
-    self.bound  = "_Part_#{rand(1024)}_#{rand(0xffffffff)}_#{rand(0xffffffff)}"
+    self.parts = []
+    random_bound = "#{rand(0xffffffff)}#{rand(0xffffffff)}#{rand(0xffffffff)}#{rand(0xffffffff)}"
+    random_bound = random_bound[0..29]
+    self.bound = "---------------------------#{random_bound}"
     self.content = ''
     if data
       head,body = data.split(/\r?\n\r?\n/, 2)

--- a/lib/rex/mime/message.rb
+++ b/lib/rex/mime/message.rb
@@ -16,9 +16,7 @@ class Message
   def initialize(data=nil)
     self.header = Rex::MIME::Header.new
     self.parts = []
-    random_bound = "#{rand(0xffffffff)}#{rand(0xffffffff)}#{rand(0xffffffff)}#{rand(0xffffffff)}"
-    random_bound = random_bound[0..29]
-    self.bound = "---------------------------#{random_bound}"
+    self.bound = "---------------------------#{Rex::Text::rand_text_numeric(30)}"
     self.content = ''
     if data
       head,body = data.split(/\r?\n\r?\n/, 2)

--- a/spec/lib/rex/mime/message_spec.rb
+++ b/spec/lib/rex/mime/message_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Rex::MIME::Message do
 
     it "creates a random bound" do
       message_class.send(:initialize)
-      expect(message_class.bound).to include('_Part_')
+      expect(message_class.bound).to include('---------------------------')
     end
 
     it "allows to populate headers from argument" do
@@ -349,40 +349,40 @@ RSpec.describe Rex::MIME::Message do
   describe "#to_s" do
     let(:regexp_mail) do
       regex = "MIME-Version: 1.0\r\n"
-      regex << "Content-Type: multipart/mixed; boundary=\"_Part_.*\"\r\n"
+      regex << "Content-Type: multipart/mixed; boundary=\"---------------------------.*\"\r\n"
       regex << "Subject: Pull Request\r\n"
       regex << "Date: .*\r\n"
       regex << "Message-ID: <.*@.*>\r\n"
       regex << "From: contributor@msfdev.int\r\n"
       regex << "To: msfdev@msfdev.int\r\n"
       regex << "\r\n"
-      regex << "--_Part_.*\r\n"
+      regex << "-----------------------------[0-9]{30}\r\n"
       regex << "Content-Disposition: inline\r\n"
       regex << "Content-Type: text/plain\r\n"
       regex << "Content-Transfer-Encoding: base64\r\n"
       regex << "\r\n"
       regex << "Q29udGVudHM=\r\n"
       regex << "\r\n"
-      regex << "--_Part_.*--\r\n"
+      regex << "-----------------------------[0-9]{30}--\r\n"
 
       Regexp.new(regex)
     end
 
     let(:regexp_web) do
-      regex = "--_Part_.*\r\n"
+      regex = "-----------------------------[0-9]{30}\r\n"
       regex << "Content-Disposition: form-data; name=\"action\"\r\n"
       regex << "\r\n"
       regex << "save\r\n"
-      regex << "--_Part_.*\r\n"
+      regex << "-----------------------------[0-9]{30}\r\n"
       regex << "Content-Disposition: form-data; name=\"file\"; filename=\"test.txt\"\r\n"
       regex << "Content-Type: application/octet-stream\r\n"
       regex << "\r\n"
       regex << "Contents\r\n"
-      regex << "--_Part_.*\r\n"
+      regex << "-----------------------------[0-9]{30}\r\n"
       regex << "Content-Disposition: form-data; name=\"title\"\r\n"
       regex << "\r\n"
       regex << "Title\r\n"
-      regex << "--_Part_.*--\r\n"
+      regex << "-----------------------------[0-9]{30}--\r\n"
 
       Regexp.new(regex)
     end


### PR DESCRIPTION
I originally discussed this in Metasploit issue [#15983](https://github.com/rapid7/metasploit-framework/issues/15983). The short version is that Metasploit modules that use Rex::Mime::Message for multipart form uploads use a multipart boundary that is easy to fingerprint because it doesn't look like Firefox, Chrome, etc. In fact, as far as I can tell, it's unique to Metasploit which makes it trivial to fingerprint.

I wanted to get the ball rolling on a fix so I started with a test target. I used [Apache Flink](https://flink.apache.org/) since it's still exploitable by `exploits/multi/http/apache_flink_jar_upload_exec` in it's most current version and it's dead simple to install and run (download, unzip, `./start-cluster.sh`).

Anyway, after playing with this I changed the `Rex::MIME::Message` boundary to mimic Firefox. I'm not really happy with that. The problem, of course, is that we use multiple User-Agents in Metasploit. So using any one boundary here is insufficient. Ideally, we'd tie the boundary to the actual User-Agent being used for the given session/request. But, that isn't trivial (or just more plumbing than I want to snake). I decided _not_ to mimic Chrome/webkit because it would look weird with the email modules that use `Rex::Mime::Message`. There aren't many but there are some: https://github.com/rapid7/metasploit-framework/search?q=Rex%3A%3AMime%3A%3AMessage

I've attached three pcaps:

1. flink_upload_unpatched.pcapng: is `apache_flink_jar_upload_exec` without this patch.
1. flink_upload_patched.pcapng is `apache_flink_jar_upload_exec` with this patch.
1. flink_upload_firefox.pcapng is just me upload a Jar to flink using Firefox.

I also wrote a Suricata rule to demonstrate fingerprinting on the unpatched version.

```
alert http any any -> any any (msg:"Metasploit exploit attempt"; flow:to_server; http.content_type; pcre:/^multipart/form-data\; boundary=_Part_[0-9]+_[0-9]+_[0-9]+$/; classtype:misc-attack; sid:211270;)
```

Note the "Alerts: 1":

```
albinolobster@ubuntu:~$ sudo suricata -v -r ~/Desktop/flink_upload_unpatched.pcapng -k none -S ./test.rule 
[sudo] password for albinolobster: 
1/3/2022 -- 17:35:53 - <Notice> - This is Suricata version 6.0.4 RELEASE running in USER mode
1/3/2022 -- 17:35:53 - <Info> - CPUs/cores online: 4
1/3/2022 -- 17:35:53 - <Info> - fast output device (regular) initialized: fast.log
1/3/2022 -- 17:35:53 - <Info> - eve-log output device (regular) initialized: eve.json
1/3/2022 -- 17:35:53 - <Info> - stats output device (regular) initialized: stats.log
1/3/2022 -- 17:35:53 - <Info> - 1 rule files processed. 1 rules successfully loaded, 0 rules failed
1/3/2022 -- 17:35:53 - <Info> - Threshold config parsed: 0 rule(s) found
1/3/2022 -- 17:35:53 - <Info> - 1 signatures processed. 0 are IP-only rules, 0 are inspecting packet payload, 1 inspect application layer, 0 are decoder event only
1/3/2022 -- 17:35:53 - <Notice> - all 5 packet processing threads, 4 management threads initialized, engine started.
1/3/2022 -- 17:35:53 - <Info> - Starting file run for /home/albinolobster/Desktop/flink_upload_unpatched.pcapng
1/3/2022 -- 17:35:53 - <Info> - pcap file /home/albinolobster/Desktop/flink_upload_unpatched.pcapng end of file reached (pcap err code 0)
1/3/2022 -- 17:35:53 - <Notice> - Signal Received.  Stopping engine.
1/3/2022 -- 17:35:53 - <Info> - time elapsed 0.040s
1/3/2022 -- 17:35:53 - <Notice> - Pcap-file module read 1 files, 105 packets, 128860 bytes
1/3/2022 -- 17:35:53 - <Info> - Alerts: 1
1/3/2022 -- 17:35:53 - <Info> - cleaning up signature grouping structure... complete
```

Not to say this is a magic solution. Another signature can now be written to find a Firefox boundary used with a Chrome User-Agent (or such), but it's a step :shrug: 

Also, what I did here to generate the boundary is a hack by some goofball that can't write Ruby to save his life. Suggestions more than welcome if we think this is a tolerable path.

[flink_upload_.zip](https://github.com/rapid7/rex-mime/files/8165816/flink_upload_.zip)
