### PR TITLE
Don't remove whitespace before every newline character. Support no CR…

### DIFF
--- a/lib/rex/mime/message.rb
+++ b/lib/rex/mime/message.rb
@@ -26,7 +26,7 @@ class Message
 
       if ctype && ctype[1] && ctype[1] =~ /multipart\/mixed;\s*boundary="?([A-Za-z0-9'\(\)\+\_,\-\.\/:=\?^\s]+)"?/
         self.bound = $1
-        chunks = body.to_s.split(/--#{self.bound}(--)?\r?\n/)
+        chunks = body.to_s.split(/--#{self.bound}(--)?\r?\n?/)
         self.content = chunks.shift.to_s.gsub(/\s+$/, '')
         self.content << "\r\n" unless self.content.empty?
 
@@ -35,7 +35,7 @@ class Message
           head,body = chunk.split(/\r?\n\r?\n/, 2)
           part = Rex::MIME::Part.new
           part.header.parse(head)
-          part.content = body.gsub(/\s+$/, '')
+          part.content = body&.delete_suffix("\r\n")
           self.parts << part
         end
       else


### PR DESCRIPTION
This fixes some parsing issues I've been having while working on SCCM. Specifically:

- Whitespace followed by newline characters was deleted. I believe the intent of this was to remove whitespace at the end of a part's content. However because the regex `$` matches _any newline_, even in the middle of the content, this corrupted binary data, wherein every `"\x0A"` character had a small-but-reasonable chance of being preceded by whitespace of some description, and having that whitespace deleted.
- In addition, consider what happens if you actually _want_ your content to end in CRLF. The existing code was over-aggressive in stripping it. The correct behaviour (per RFC2046) is to treat the final CRLF before a boundary as "part of the boundary", and then (to quote the spec), "Body parts that must be considered to end with line breaks, therefore, must have two CRLFs preceding the boundary delimiter line, the first of which is part of the preceding body part, and the second of which is part of the encapsulation boundary." We should therefore only remove _one_ CRLF, otherwise there's a 1-in-65536 chance that any arbitrary random binary data happens to end in `"\x0D\x0A"`, which would be incorrectly stripped. This is why I've modified the `"allows to populate parts contents from argument"` test case, which I believe was incorrect.
- If the final `--boundary--` didn't have CRLF after it (as is the case from an SCCM server), it would not recognise that as a valid boundary.
